### PR TITLE
Remove unneeded python3 dependency from GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,10 +27,6 @@ jobs:
         with:
           version: v3.4.0
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
 


### PR DESCRIPTION
Testing CI.